### PR TITLE
Adds support for a pair argument.  Also addresses multibyte offset issue

### DIFF
--- a/ext/tokenizers/src/lib.rs
+++ b/ext/tokenizers/src/lib.rs
@@ -39,7 +39,7 @@ fn init() -> RbResult<()> {
         method!(RbTokenizer::add_special_tokens, 1),
     )?;
     class.define_method("add_tokens", method!(RbTokenizer::add_tokens, 1))?;
-    class.define_method("_encode", method!(RbTokenizer::encode, 2))?;
+    class.define_method("_encode", method!(RbTokenizer::encode, 3))?;
     class.define_method("decode", method!(RbTokenizer::decode, 1))?;
     class.define_method("decoder=", method!(RbTokenizer::set_decoder, 1))?;
     class.define_method("pre_tokenizer=", method!(RbTokenizer::set_pre_tokenizer, 1))?;

--- a/ext/tokenizers/src/tokenizer.rs
+++ b/ext/tokenizers/src/tokenizer.rs
@@ -42,10 +42,16 @@ impl RbTokenizer {
         // TODO return self
     }
 
-    pub fn encode(&self, sequence: String, add_special_tokens: bool) -> RbResult<RbEncoding> {
+    pub fn encode(&self, sequence: String, pair: Option<String>, add_special_tokens: bool) -> RbResult<RbEncoding> {
+        let input = match pair {
+            Some(pair) => {
+                tk::EncodeInput::Dual(sequence.into(), pair.into())
+            }
+            None => tk::EncodeInput::Single(sequence.into()),
+        };
         self.tokenizer
             .borrow()
-            .encode(sequence, add_special_tokens)
+            .encode_char_offsets(input, add_special_tokens)
             .map(|v| RbEncoding { encoding: v })
             .map_err(RbError::from)
     }

--- a/lib/tokenizers/tokenizer.rb
+++ b/lib/tokenizers/tokenizer.rb
@@ -1,12 +1,12 @@
 module Tokenizers
   class Tokenizer
     # TODO change add_special_tokens default to true in 0.3.0
-    def encode(sequence, add_special_tokens: nil)
+    def encode(sequence, pair = nil, add_special_tokens: nil)
       if add_special_tokens.nil?
         warn "[tokenizers] add_special_tokens will default to true in 0.3.0. Pass add_special_tokens: true/false to silence this warning."
         add_special_tokens = false
       end
-      _encode(sequence, add_special_tokens)
+      _encode(sequence, pair, add_special_tokens)
     end
   end
 end

--- a/test/tokenizers_test.rb
+++ b/test/tokenizers_test.rb
@@ -75,4 +75,24 @@ class TokenizersTest < Minitest::Test
     assert_equal 1169, tokenizer.token_to_id("can")
     assert_equal "magic", tokenizer.id_to_token(3974)
   end
+
+  def test_multibyte_offsets
+     tokenizer = Tokenizers.from_pretrained("gpt2")
+     encoded = tokenizer.encode("I wanted to convert 10000 ¥ to $.", add_special_tokens: true)
+     expected_tokens = ["I", "Ġwanted", "Ġto", "Ġconvert", "Ġ10000", "ĠÂ¥", "Ġto", "Ġ$", "."]
+     expected_offsets = [[0, 1], [1, 8], [8, 11], [11, 19], [19, 25], [25, 27], [27, 30], [30, 32], [32, 33]]
+
+     assert_equal expected_tokens, encoded.tokens
+     assert_equal expected_offsets, encoded.offsets
+  end
+
+  def test_pair_encoding
+    tokenizer = Tokenizers.from_pretrained("bert-base-cased")
+    question = "Am I allowed to pass two text arguments?"
+    answer = "Yes I am!"
+    encoded = tokenizer.encode(question, answer, add_special_tokens: true)
+
+    expected_tokens = ["[CLS]", "Am", "I", "allowed", "to", "pass", "two", "text", "arguments", "?", "[SEP]", "Yes", "I", "am", "!", "[SEP]"]
+    assert_equal expected_tokens, encoded.tokens
+  end
 end


### PR DESCRIPTION
The Python encode allows the passing of two arguments - a sequence and a pair - that are subsequently combined and encoded.  This makes sense in certain prompt/completion or question/answer workflows.  This adds support for an optional pair.

Additionally, when I was looking at the Rust implementation, I noted a distinction between the code that the Python binding was calling (encode_char_offsets) and what the Ruby binding was calling (encode) on the underlying Rust tokenizer.  This leads to a difference in how offsets are calculated for strings that contain multibyte characters in the tokenizer vocabulary.  I updated the binding to call a function matching the Python version.